### PR TITLE
DRR_Template.Rmd

### DIFF
--- a/DRR_Template.Rmd
+++ b/DRR_Template.Rmd
@@ -41,6 +41,9 @@ csl: https://raw.githubusercontent.com/citation-style-language/styles/master/apa
 link-citations: yes
 output:
   html_document:
+    pandoc_args: [
+      "--number-offset=1,0"
+    ]
     df_print: kable
     fig_caption: true
     dev: svg
@@ -135,7 +138,7 @@ knitr::opts_chunk$set(
    dev = "svg",
    fig.path = "figures/",
    tidy.opts = list(width.cutoff = 60),
-   tidy = TRUE
+   tidy = F
    )
 # if ggplot, update theme to default to centered titles
 if ("ggplot2" %in% .packages()) {

--- a/DRR_Template.Rmd
+++ b/DRR_Template.Rmd
@@ -42,7 +42,7 @@ link-citations: yes
 output:
   html_document:
     pandoc_args: [
-      "--number-offset=1,0"
+      "--number-offset=0,0"
     ]
     df_print: kable
     fig_caption: true


### PR DESCRIPTION
1. Line 44-46: Added pandoc_arg in YAML output configuration because the 'title' element was generating an error
2. Line 138: Changed knitr::opts_chunk$set "tidy" parameter from 'True' to 'False'; set to True was generating a string parsing error